### PR TITLE
handle errors when fetching an S3 upload token

### DIFF
--- a/juicebox_cli/cli.py
+++ b/juicebox_cli/cli.py
@@ -87,7 +87,7 @@ def upload(ctx, client, env, app, job, netrc, files):
         logger.debug(message)
         click.echo(click.style(message, fg='red'))
         ctx.abort()
-    except AuthenticationError as exc_info:
+    except Exception as exc_info:
         click.echo(click.style(str(exc_info), fg='red'))
         ctx.abort()
 

--- a/juicebox_cli/upload.py
+++ b/juicebox_cli/upload.py
@@ -46,6 +46,9 @@ class S3Uploader:
         elif response.status_code == 409:
             logger.debug(response)
             raise ValueError(response.json()['error'])
+        elif response.status_code != 200:
+            logger.debug(response)
+            raise Exception("Couldn't get an S3 upload token.")
         credentials = response.json()
         logger.debug('Successfully retrieved STS S3 Upload token')
         return credentials


### PR DESCRIPTION
Type: fly-by fix

when making the request to the "upload-token" endpoint, the juicebox CLI would handle some specific status codes, but really it should raise an exception any time the response is not a 200 (see https://github.com/juiceinc/juicebox-public-api/blob/630695b8d2f029d192e57c6ccdbf916bfcdc9e66/juicebox_public_api/resources/sts.py#L34 for where we set the status code in the response for this endpoint).

In addition, I widened the top-level exception handling to handle *any* exception, while printing the exception message.