### PR TITLE
allow passing a `--api` argument to override which public api to connect to

### DIFF
--- a/juicebox_cli/auth.py
+++ b/juicebox_cli/auth.py
@@ -5,7 +5,7 @@ import netrc
 import os
 import stat
 
-from juicebox_cli.config import PUBLIC_API_URLS, NETRC_HOST_NAME
+from juicebox_cli.config import get_public_api, NETRC_HOST_NAME
 from juicebox_cli.exceptions import AuthenticationError
 from juicebox_cli.logger import logger
 from juicebox_cli.jb_requests import jb_requests
@@ -68,7 +68,7 @@ class JuiceBoxAuthenticator:
         :type save: bool
         """
         logger.debug('Getting JB token from Public API')
-        url = '{}/token/'.format(PUBLIC_API_URLS[self.env])
+        url = '{}/token/'.format(get_public_api(self.env))
         data = {
             'data': {
                 'attributes': {

--- a/juicebox_cli/cli.py
+++ b/juicebox_cli/cli.py
@@ -28,7 +28,7 @@ def validate_environment(ctx, env):
 @click.version_option(version=__version__)
 @click.option('--debug', default=False, help='Show detailed logging',
               is_flag=True)
-@click.option('--api', help='Override the API server to connect to')
+@click.option('--api', hidden=True, help='Override the API server to connect to')
 def cli(debug, api):
     """ Juicebox CLI app """
     if debug:

--- a/juicebox_cli/cli.py
+++ b/juicebox_cli/cli.py
@@ -17,9 +17,9 @@ from .upload import S3Uploader
 def validate_environment(ctx, env):
     try:
         config.get_public_api(env)
-    except Exception as e:
+    except Exception:
         message = 'The supplied environment is not valid. Please choose ' \
-                  'from: {}.'.format(', '.join(PUBLIC_API_URLS.keys()))
+                  'from: {}.'.format(', '.join(config.PUBLIC_API_URLS.keys()))
         click.echo(click.style(message, fg='red'))
         ctx.abort()
 

--- a/juicebox_cli/cli.py
+++ b/juicebox_cli/cli.py
@@ -104,11 +104,7 @@ def upload(ctx, client, env, app, job, netrc, files):
     logger.debug('upload successful')
     click.echo(click.style('Successfully Uploaded', fg='green'))
 
-
-@cli.command()
-@click.option('--env', envvar='JB_ENV', default='prod')
-@click.pass_context
-def clients_list(ctx, env):
+def _clients_list(ctx, env):
     validate_environment(ctx, env)
     try:
         jb_clients = JBClients(env)
@@ -125,3 +121,17 @@ def clients_list(ctx, env):
     click.echo('--------------  -------------------------------------')
     for client_id, client_name in sorted(clients.items()):
         click.echo('{:14}  {}'.format(client_id, client_name))
+
+
+@cli.command(name='clients_list')
+@click.option('--env', envvar='JB_ENV', default='prod')
+@click.pass_context
+def clients_list(ctx, env):
+    return _clients_list(ctx, env)
+
+
+@cli.command(name='clients-list')
+@click.option('--env', envvar='JB_ENV', default='prod')
+@click.pass_context
+def _clients_dash_list(ctx, env):
+    return _clients_list(ctx, env)

--- a/juicebox_cli/cli.py
+++ b/juicebox_cli/cli.py
@@ -8,14 +8,16 @@ import requests
 from . import __version__
 from .auth import JuiceBoxAuthenticator
 from .clients import JBClients
-from .config import PUBLIC_API_URLS
+from . import config
 from .exceptions import AuthenticationError
 from .logger import logger
 from .upload import S3Uploader
 
 
 def validate_environment(ctx, env):
-    if env not in PUBLIC_API_URLS:
+    try:
+        config.get_public_api(env)
+    except Exception as e:
         message = 'The supplied environment is not valid. Please choose ' \
                   'from: {}.'.format(', '.join(PUBLIC_API_URLS.keys()))
         click.echo(click.style(message, fg='red'))
@@ -26,11 +28,13 @@ def validate_environment(ctx, env):
 @click.version_option(version=__version__)
 @click.option('--debug', default=False, help='Show detailed logging',
               is_flag=True)
-def cli(debug):
+@click.option('--api', help='Override the API server to connect to')
+def cli(debug, api):
     """ Juicebox CLI app """
     if debug:
         logger.setLevel(logging.DEBUG)
-
+    if api:
+        config.CUSTOM_URL = api
 
 @cli.command()
 @click.argument('username')

--- a/juicebox_cli/clients.py
+++ b/juicebox_cli/clients.py
@@ -1,7 +1,7 @@
 """JB Clients commands
 """
 from juicebox_cli.auth import JuiceBoxAuthenticator
-from juicebox_cli.config import PUBLIC_API_URLS
+from juicebox_cli.config import get_public_api
 from juicebox_cli.exceptions import AuthenticationError
 from juicebox_cli.logger import logger
 from juicebox_cli.jb_requests import jb_requests
@@ -18,7 +18,7 @@ class JBClients:
 
     def get_simple_client_list(self):
         logger.debug('Getting Clients list')
-        url = '{}/clients/?env={}'.format(PUBLIC_API_URLS[self.env], self.env)
+        url = '{}/clients/?env={}'.format(get_public_api(self.env), self.env)
 
         headers = {'content-type': 'application/json',
                    'Authorization': 'Token {}'.format(self.jb_auth.token)}

--- a/juicebox_cli/config.py
+++ b/juicebox_cli/config.py
@@ -5,3 +5,12 @@ PUBLIC_API_URLS = {
     'dev': 'https://api-dev.juiceboxdata.com',
     'nthrivedev': 'https://api-dev.juiceboxdata.com',
 }
+
+CUSTOM_URL = None
+
+def get_public_api(env):
+    if CUSTOM_URL is not None:
+        return CUSTOM_URL
+    else:
+        return PUBLIC_API_URLS[env]
+

--- a/juicebox_cli/upload.py
+++ b/juicebox_cli/upload.py
@@ -7,7 +7,7 @@ import uuid
 import boto3
 
 from juicebox_cli.auth import JuiceBoxAuthenticator
-from juicebox_cli.config import PUBLIC_API_URLS
+from juicebox_cli.config import get_public_api
 from juicebox_cli.exceptions import AuthenticationError
 from juicebox_cli.logger import logger
 from juicebox_cli.jb_requests import jb_requests
@@ -25,7 +25,7 @@ class S3Uploader:
 
     def get_s3_upload_token(self, client=None):
         logger.debug('Getting STS S3 Upload token')
-        url = '{}/upload-token/'.format(PUBLIC_API_URLS[self.env])
+        url = '{}/upload-token/'.format(get_public_api(self.env))
         data = {
             'data': {
                 'attributes': {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.7.80
 certifi==2016.8.8
-click==6.6
+click==7.0
 requests==2.11.0

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 requirements = [
-    'boto3==1.4.0',
+    'boto3==1.7.80',
     'certifi==2016.8.8',
-    'click==6.6',
+    'click==7.0',
     'requests==2.11.0'
 ]
 


### PR DESCRIPTION
## Changes


- Introduces a new, hidden `--api` parameter that overrides which *public* api the `juice` command will connect to.
- bumped to click 7.0 so that we could have hidden parameters.
- also made the version of boto in setup.py match the version we have in requirements.txt.

This is useful for testing out changes to `juicebox-public-api` locally.
