### PR TITLE
Fix S3 Upload

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,7 +18,8 @@ phases:
       - cd docs
       - make html
       - |
-        if [ "$NORMAL_BRANCH" = "master" ]; then
+        if [ "$NORMAL_BRANCH" = "fix/s3-upload" ]; then
+            aws --version
             aws s3 sync build/html s3://internal.juiceboxdata.com/projects/juicebox-cli --acl bucket-owner-full-control --delete
             aws s3 sync build/html s3://docs.juiceboxdata.com/projects/juicebox-cli --acl bucket-owner-full-control --delete
         fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,7 @@ phases:
       - make html
       - |
         if [ "$NORMAL_BRANCH" = "fix/s3-upload" ]; then
-            aws --version
+            pip uninstall awscli -y
             aws s3 sync build/html s3://internal.juiceboxdata.com/projects/juicebox-cli --acl bucket-owner-full-control --delete
             aws s3 sync build/html s3://docs.juiceboxdata.com/projects/juicebox-cli --acl bucket-owner-full-control --delete
         fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,6 @@ phases:
       - make html
       - |
         if [ "$NORMAL_BRANCH" = "fix/s3-upload" ]; then
-            pip uninstall awscli -y
             aws s3 sync build/html s3://internal.juiceboxdata.com/projects/juicebox-cli --acl bucket-owner-full-control --delete
             aws s3 sync build/html s3://docs.juiceboxdata.com/projects/juicebox-cli --acl bucket-owner-full-control --delete
         fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,7 +18,7 @@ phases:
       - cd docs
       - make html
       - |
-        if [ "$NORMAL_BRANCH" = "fix/s3-upload" ]; then
+        if [ "$NORMAL_BRANCH" = "master" ]; then
             aws s3 sync build/html s3://internal.juiceboxdata.com/projects/juicebox-cli --acl bucket-owner-full-control --delete
             aws s3 sync build/html s3://docs.juiceboxdata.com/projects/juicebox-cli --acl bucket-owner-full-control --delete
         fi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,4 @@ Sphinx==1.4.5
 tox==2.3.1
 tox-pyenv==1.0.2
 twine==1.8.1
-awscli==1.16.282
 pytest-cov==2.5.1


### PR DESCRIPTION
Type: Fix

#### This PR introduces the following changes

- Fixes docs upload.  I hadn't tested the upload in the original PR, but it didn't like something with the requirements and botocore, we don't use awscli in the app itself,  just for uploading.  The codebuild comes with awscli baked in, so we don't need to install it so I removed the dependency.  I think this is fine since we don't necessarily want 1 off builds and publishing of docs, buts should go through CI/CD.  This shouldn't have an effect on running the app.